### PR TITLE
Using rev-parse instead of status to check for git repo.

### DIFF
--- a/OpenInGitRepository.py
+++ b/OpenInGitRepository.py
@@ -34,7 +34,7 @@ class OpenInGitRepositoryCommand(sublime_plugin.WindowCommand):
 
     def _is_git_repository(self, path):
         exit_code = subprocess.call(
-            ['git', '-C', path, 'status'], stdout=open(os.devnull, 'w'),
+            ['git', '-C', path, 'rev-parse'], stdout=open(os.devnull, 'w'),
             stderr=subprocess.STDOUT)
         return exit_code == 0
 


### PR DESCRIPTION
This helps greatly for performance. I've noticed with `status` that right clicking on menu was slow. Status checks for changes in repo every time and scans whole repo whereas `rev-parse` basically does nothing but still can be used in status code check approach.