### PR TITLE
Fixed error 'NoneType' object has no attribute 'group'.

### DIFF
--- a/OpenInGitRepository.py
+++ b/OpenInGitRepository.py
@@ -53,7 +53,7 @@ class OpenInGitRepositoryCommand(sublime_plugin.WindowCommand):
         output = output.decode('utf-8')
         if not output:
             return None
-        match = re.match(r'\w+\s(.+)(?= )', output)
+        match = re.match(r'[\w-]+\s(.+)(?= )', output)
         return match.group(1)
 
     def _normalize_remote_url(self, url):


### PR DESCRIPTION
This commit adds dash `-` to the regex to successfully match the remote name with dashes.

Example: `some-name git@github.com:vovayatsyuk/project-name.git (fetch)`